### PR TITLE
Add option to use % movement without mappings

### DIFF
--- a/autoload/jumpmethod.vim
+++ b/autoload/jumpmethod.vim
@@ -20,15 +20,19 @@ endfunction
 " Jump to the matching bracket.  Same as "%" but makes sure to keep the
 " last-cursor mark.
 function! jumpmethod#JumpToMatchingBracket()
-  " Use "normal" rather than "normal!" to make use of improved mappings for "%".
-  " keepjumps does all we need to retain jump marks, unless "%" has been mapped
-  " to a better version, in which case it may still lose our marks, so
-  " explicitly store and recall them.  We still use keepjumps though as it also
-  " retains the whole old-jump list (accessed using Ctrl+O & Ctrl+I).
-  " I don't know how to retain the whole jump list if "%" has been mapped.
-  let lastCursorPos = getpos("''")
-  keepjumps normal %
-  call setpos("''", lastCursorPos)
+  if !g:jumpmethod_default_percent
+    " Use "normal" rather than "normal!" to make use of improved mappings for "%".
+    " keepjumps does all we need to retain jump marks, unless "%" has been mapped
+    " to a better version, in which case it may still lose our marks, so
+    " explicitly store and recall them.  We still use keepjumps though as it also
+    " retains the whole old-jump list (accessed using Ctrl+O & Ctrl+I).
+    " I don't know how to retain the whole jump list if "%" has been mapped.
+    let lastCursorPos = getpos("''")
+    keepjumps normal %
+    call setpos("''", lastCursorPos)
+  else
+    keepjumps normal! %
+  endif
 endfunction
 
 " Strip trailing comment

--- a/autoload/jumpmethod/plug.vim
+++ b/autoload/jumpmethod/plug.vim
@@ -71,3 +71,9 @@ function! jumpmethod#plug#map_to_plug_in_buffer()
     map <buffer> gd <Plug>(jumpmethod-gd)
     map <buffer> gD <Plug>(jumpmethod-gD)
 endf
+
+
+" Options 
+if !exists("g:jumpmethod_default_percent")
+   let g:jumpmethod_default_percent = 0
+endif


### PR DESCRIPTION
Hello,

First, thanks for the improvements made over the original plugin!

I've just switched from the function in StackOverflow's response, and the only downside I found was that the jump list is being polluted. Despite the `''` mark can be used to go back, I usually find useful to be able to navigate with <kbd>Ctrl</kbd>+<kbd>i</kbd> and <kbd>Ctrl</kbd>+<kbd>o</kbd>.

From what I understood, this is caused by the mapping of the % movement.

After some investigation I'm also lost about how to avoid the issue when the "%" is mapped.
The most common mapping is to use the matchit plugin, which is mentioned in [`:help %`](http://vimhelp.appspot.com/motion.txt.html#%25).
And this issue has been discussed already without any solution:

1. https://vim-use.narkive.com/tdtnMNHv/keepjumps
2. https://github.com/neovim/neovim/issues/8478

I've also made some tests in the current C++ project I'm working and I haven't found any issues when disabling the "%" mapping; in fact, it always jumped correctly and in some cases faster. 

But I imagine it could be necessary for some projects, so I think it'd be good to be able to switch between these behaviors.

